### PR TITLE
Build MicroProfile OpenAPI w/Java 11

### DIFF
--- a/buildScripts/release.groovy
+++ b/buildScripts/release.groovy
@@ -53,7 +53,7 @@ pipeline {
                                 settings = '-s ../output-settings.xml -Pmp-staging'
                             }
 
-                            if (params.module == 'microprofile-metrics' || params.module == 'microprofile-telemetry' || params.module == 'microprofile-parent') {
+                            if (params.module == 'microprofile-metrics' || params.module == 'microprofile-telemetry' || params.module == 'microprofile-parent' || params.module == 'microprofile-open-api') {
                                 withEnv(["JAVA_HOME=${tool 'adoptopenjdk-hotspot-jdk11-latest'}", "PATH=${tool 'adoptopenjdk-hotspot-jdk11-latest'}/bin:${env.PATH}"]) {
                                     sh "mvn -q -N io.takari:maven:0.7.7:wrapper -Dmaven=3.9.0 && ./mvnw -v"
                                     sh "./mvnw ${settings} release:prepare release:perform -B -Dtag=${params.tag} -DdevelopmentVersion=${params.snapshotVersion} -DreleaseVersion=${params.releaseVersion} -Drevremark=${params.revremark} -Drelease.revision=${params.revremark} -DstagingProgressTimeoutMinutes=20"


### PR DESCRIPTION
OpenAPI has been updated to use microprofile-parent 2.7 in order to support the impsort plugin on Maven 3.9. The newer version of the plugin also requires JDK 11.